### PR TITLE
Handle duplicate email subscription error

### DIFF
--- a/src/components/subscribe/subscribe.tsx
+++ b/src/components/subscribe/subscribe.tsx
@@ -37,6 +37,13 @@ export const Subscribe: FC = () => {
       );
 
       if (!response.ok) {
+        if (response.status === 409) {
+          setMessage({
+            type: "error",
+            text: "This email is already subscribed to our newsletter.",
+          });
+          return;
+        }
         throw new Error(`HTTP error! status: ${response.status}`);
       }
 


### PR DESCRIPTION
- Added a check for HTTP status 409 to display an error message when a user tries to subscribe with an email that is already in use.